### PR TITLE
Enumerations not showing

### DIFF
--- a/src/gquery.py
+++ b/src/gquery.py
@@ -161,14 +161,16 @@ def get_enumeration(rq, v, endpoint, metadata={}, auth=None):
     '''
     Returns a list of enumerated values for variable 'v' in query 'rq'
     '''
+    v = v.replace('_', '')
+
     # We only fire the enum filling queries if indicated by the query metadata
     if 'enumerate' not in metadata:
         return []
-    if v in metadata['enumerate']:
-        return get_enumeration_sparql(rq, v, endpoint, auth)
     enumDict = _getDictWithKey(v, metadata['enumerate'])
     if enumDict:
         return enumDict[v]
+    if v in metadata['enumerate']:
+        return get_enumeration_sparql(rq, v, endpoint, auth)
     return []
 
 def get_enumeration_sparql(rq, v, endpoint, auth=None):

--- a/tests/test_gquery.py
+++ b/tests/test_gquery.py
@@ -81,10 +81,10 @@ class TestGQuery(unittest.TestCase):
     def test_get_static_enumeration(self):
         rq, _ = self.loader.getTextForName('test-enum')
 
-        metadata = gquery.get_metadata(rq, '')
+        metadata = gquery.get_yaml_decorators(rq)
         self.assertIn('enumerate', metadata, 'Should contain enumerate')
 
-        enumeration = gquery.get_enumeration(rq, 'o', 'http://mock-endpoint/sparql', metadata)
+        enumeration = gquery.get_enumeration(rq, '_o', 'http://mock-endpoint/sparql', metadata)
         self.assertIsInstance(enumeration, list, 'Should return a list of values')
         self.assertEquals(len(enumeration), 2, 'Should have two elements')
 


### PR DESCRIPTION
Queries with static enumerations are not showing properly because they are not being parsed adequately.